### PR TITLE
drop python 3.9 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,8 @@ jobs:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v2
     with:
       submodules: false
-      # Any env name which does not start with `pyXY` will use this Python version.
-      default_python: '3.12'
       envs: |
+        - linux: py314
         - linux: py313
         - linux: py312
         - linux: py312-oldasdf
@@ -50,13 +49,9 @@ jobs:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v2
     with:
       submodules: false
-      # Any env name which does not start with `pyXY` will use this Python version.
-      default_python: '3.12'
       envs: |
-        - linux: py314
-          python-version: '3.14-dev'
         # separate pytest so a failure here doesn't cause the whole suite to fail
-        - linux: py312-pytestdev
+        - linux: py313-pytestdev
 
   downstream:
     if: (!contains(github.event.pull_request.labels.*.name, 'Skip Downstream'))
@@ -65,7 +60,7 @@ jobs:
     with:
       submodules: false
       # Any env name which does not start with `pyXY` will use this Python version.
-      default_python: '3.12'
+      default_python: '3.13'
       envs: |
         - linux: downstream-standard
         - linux: downstream-transform

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ description = "Pytest plugin for testing ASDF schemas"
 readme = 'README.rst'
 license-files = ['LICENSE']
 authors = [{ name = 'The ASDF Developers' }]
-requires-python = '>=3.9'
+requires-python = '>=3.10'
 classifiers = [
   'Development Status :: 5 - Production/Stable',
   'Programming Language :: Python',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 env_list =
-# Everything should work for python 39 310 311 but the pytester plugin
+# Everything should work for python 310 311 but the pytester plugin
 # used to test this plugin loses this plugin after the first test run.
     py{312,313}{,-coverage}{,-pytestdev}{,-oldasdf}
     downstream-{standard,transform,wcs,coordinates,astropy,rad,stdatamodels,sunpy,dkist,weldx}


### PR DESCRIPTION
Similar to: https://github.com/asdf-format/asdf/pull/1992

Drop support for Python 3.9 (which is end-of-life).

Also update a few CI jobs to newer python versions.