### PR TITLE
Fix compatibility with `pytest-run-parallel`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
         - linux: py313
         - linux: py312
         - linux: py312-oldasdf
+        - linux: py314-pytest-plugin-compat
 
   dev:
     needs: [core]

--- a/src/pytest_asdf_plugin/plugin.py
+++ b/src/pytest_asdf_plugin/plugin.py
@@ -115,6 +115,8 @@ class AsdfSchemaFile(pytest.File):
 
 
 class AsdfSchemaItem(pytest.Item):
+    _parallel_custom_item = ()
+
     @classmethod
     def from_parent(cls, parent, schema_path, validate_default=True, **kwargs):
         if hasattr(super(), "from_parent"):
@@ -181,6 +183,8 @@ class SchemaExample:
 
 
 class AsdfSchemaExampleItem(pytest.Item):
+    _parallel_custom_item = ()
+
     @classmethod
     def from_parent(
         cls,

--- a/src/pytest_asdf_plugin/plugin.py
+++ b/src/pytest_asdf_plugin/plugin.py
@@ -115,6 +115,8 @@ class AsdfSchemaFile(pytest.File):
 
 
 class AsdfSchemaItem(pytest.Item):
+    # Required to avoid warnings from `pytest-run-parallel` plugin
+    # See: https://github.com/Quansight-Labs/pytest-run-parallel/blob/9bb1215a3479e3f3d91fb0eacbd17c71dcdb08a2/src/pytest_run_parallel/plugin.py#L265
     _parallel_custom_item = ()
 
     @classmethod
@@ -183,6 +185,8 @@ class SchemaExample:
 
 
 class AsdfSchemaExampleItem(pytest.Item):
+    # Required to avoid warnings from `pytest-run-parallel` plugin
+    # See: https://github.com/Quansight-Labs/pytest-run-parallel/blob/9bb1215a3479e3f3d91fb0eacbd17c71dcdb08a2/src/pytest_run_parallel/plugin.py#L265
     _parallel_custom_item = ()
 
     @classmethod

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,3 +1,5 @@
+import importlib.util
+
 import pytest
 
 # the example schemas have a number of successes and failures
@@ -101,6 +103,13 @@ def test_skips(pytester, skip_cfg, passes, failures, skips):
     result.assert_outcomes(passed=passes, failed=failures, skipped=skips)
 
 
+@pytest.mark.skipif(
+    importlib.util.find_spec("pytest_run_parallel") is not None,
+    reason=(
+        "pytest-run-parallel causes xpass results to be incorrectly reported "
+        "(https://github.com/Quansight-Labs/pytest-run-parallel/issues/180)"
+    ),
+)
 @pytest.mark.parametrize(
     "xfail_cfg, xpasses, xfailures",
     (

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,5 +1,3 @@
-import importlib.util
-
 import pytest
 
 # the example schemas have a number of successes and failures
@@ -103,13 +101,6 @@ def test_skips(pytester, skip_cfg, passes, failures, skips):
     result.assert_outcomes(passed=passes, failed=failures, skipped=skips)
 
 
-@pytest.mark.skipif(
-    importlib.util.find_spec("pytest_run_parallel") is not None,
-    reason=(
-        "pytest-run-parallel causes xpass results to be incorrectly reported "
-        "(https://github.com/Quansight-Labs/pytest-run-parallel/issues/180)"
-    ),
-)
 @pytest.mark.parametrize(
     "xfail_cfg, xpasses, xfailures",
     (

--- a/tox.ini
+++ b/tox.ini
@@ -2,13 +2,14 @@
 env_list =
 # Everything should work for python 310 311 but the pytester plugin
 # used to test this plugin loses this plugin after the first test run.
-    py{312,313}{,-coverage}{,-pytestdev}{,-oldasdf}
+    py{312,313}{,-coverage}{,-pytestdev}{,-oldasdf}{,-pytest-plugin-compat}
     downstream-{standard,transform,wcs,coordinates,astropy,rad,stdatamodels,sunpy,dkist,weldx}
 
 [testenv]
 deps =
     coverage: coverage
     pytestdev: git+https://github.com/pytest-dev/pytest
+    pytest-plugin-compat: pytest-run-parallel
 # Install a version of asdf that doesn't have any checks for this new pytest plugin
 # This should result in the test suite in this package running using the plugin
 # that is bundled with asdf. At the moment the goal is to make everything pass
@@ -16,7 +17,6 @@ deps =
 # we will add new features and tests here that will require either removing this
 # test or skipping some tests for old asdf versions.
     oldasdf: asdf==4.3.0
-extras = all,tests
 package = editable
 commands_pre =
     pip freeze

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ env_list =
 deps =
     coverage: coverage
     pytestdev: git+https://github.com/pytest-dev/pytest
-    pytest-plugin-compat: pytest-run-parallel
+    pytest-plugin-compat: pytest-run-parallel>=0.9.1
 # Install a version of asdf that doesn't have any checks for this new pytest plugin
 # This should result in the test suite in this package running using the plugin
 # that is bundled with asdf. At the moment the goal is to make everything pass


### PR DESCRIPTION
## Description
* Added `_parallel_custom_item` attribute to custom `pytest.Item` classes to suppress warning from `pytest-run-parallel` plugin

Closes #14